### PR TITLE
Fix chat timestamps being off in recent messagelog

### DIFF
--- a/back/src/lib/logger.ts
+++ b/back/src/lib/logger.ts
@@ -14,7 +14,7 @@ export const writeToLog = (type: string, messages: Array<any>) => {
     csv.stringify(
       messages.map((x) => {
         if (x.time) {
-          x.time = formatDate(x.time);
+          return {...x, time: formatDate(x.time)};
         }
         return x;
       }),
@@ -45,7 +45,7 @@ const processFile = async (file: string) => {
       username: record[0],
       message: record[1],
       icon: record[2],
-      time: moment(record[3]),
+      time: moment.utc(record[3]),
     });
   }
   return records;


### PR DESCRIPTION
This changes writeToLog so that it makes a copy of the message object before replacing the time with the formatted date string (otherwise that ends up affecting the timestamp in other arrays like recentMsgs).

It also forces timestamps read from logfiles to be interpreted as UTC. (I didn't touch formatDate, but I think it should include the UTC marker too, just to be unambiguous).